### PR TITLE
feat: add ORM models for Video and Job

### DIFF
--- a/application/repositories/job.go
+++ b/application/repositories/job.go
@@ -1,0 +1,60 @@
+package repositories
+
+import (
+	"encoder/domain"
+	"time"
+
+	"github.com/asaskevich/govalidator"
+)
+
+func init() {
+	govalidator.SetFieldsRequiredByDefault(true)
+}
+
+type Job struct {
+	ID        string `gorm:"type:uuid;primary_key"`
+	VideoID   string `gorm:"column:video_id;type:uuid REFERENCES videos(id);notnull"`
+	Status    string
+	Video     *Video
+	Error     string
+	CreatedAt time.Time `gorm:"autoCreateTime"`
+	UpdatedAt time.Time `gorm:"autoUpdateTime"`
+}
+
+func ToJobORM(job *domain.Job) (*Job, error) {
+	err := job.Validate()
+	if err != nil {
+		return nil, err
+	}
+
+	// Convert video domain to video ORM before adding it to the job ORM
+	videoORM := &Video{
+		ID:         job.Video.Id,
+		ResourceID: job.Video.ResourceId,
+		FilePath:   job.Video.FilePath,
+	}
+	jobORM := &Job{
+		ID:      job.Id,
+		VideoID: job.Video.Id,
+		Video:   videoORM,
+		Status:  string(job.Status),
+		Error:   job.Error,
+	}
+	return jobORM, nil
+}
+
+func (job *Job) ToJobDomain() (*domain.Job, error) {
+	status, err := domain.OperationStatusFromString(job.Status)
+	if err != nil {
+		return nil, err
+	}
+	videoDomain, err := domain.NewVideo(job.Video.ID, job.Video.ResourceID, job.Video.FilePath)
+	if err != nil {
+		return nil, err
+	}
+	jobDomain, err := domain.NewJob(job.ID, status, videoDomain)
+	if err != nil {
+		return nil, err
+	}
+	return jobDomain, nil
+}

--- a/application/repositories/job_test.go
+++ b/application/repositories/job_test.go
@@ -1,0 +1,41 @@
+package repositories_test
+
+import (
+	"encoder/application/repositories"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestJobsConversion(t *testing.T) {
+	video, job := generateDomainResources()
+
+	jobOrm, err := repositories.ToJobORM(job)
+
+	require.Nil(t, err)
+	require.Equal(t, job.Id, jobOrm.ID)
+	require.Equal(t, video.Id, jobOrm.Video.ID)
+
+	jobDomain, err := jobOrm.ToJobDomain()
+
+	require.Nil(t, err)
+	require.Equal(t, jobOrm.ID, jobDomain.Id)
+	require.EqualValues(t, video, jobDomain.Video)
+}
+
+func TestJobsInvalidConversion(t *testing.T) {
+	_, job := generateDomainResources()
+	job.Id = "invalid-id"
+
+	_, err := repositories.ToJobORM(job)
+
+	require.Error(t, err)
+
+	invalidJobOrm := &repositories.Job{
+		ID: "invalid-id",
+	}
+
+	_, err = invalidJobOrm.ToJobDomain()
+
+	require.Error(t, err)
+}

--- a/application/repositories/video.go
+++ b/application/repositories/video.go
@@ -1,0 +1,63 @@
+package repositories
+
+import (
+	"encoder/domain"
+	"time"
+)
+
+type Video struct {
+	ID         string    `gorm:"type:uuid;primary_key"`
+	ResourceID string    `gorm:"type:varchar(255)"`
+	FilePath   string    `gorm:"type:varchar(255)"`
+	Jobs       []*Job    `gorm:"ForeignKey:VideoID"`
+	CreatedAt  time.Time `gorm:"autoCreateTime"`
+	UpdatedAt  time.Time `gorm:"autoUpdateTime"`
+}
+
+func ToVideoORM(video *domain.Video) (*Video, error) {
+	err := video.Validate()
+	if err != nil {
+		return nil, err
+	}
+
+	videoORM := &Video{
+		ID:         video.Id,
+		ResourceID: video.ResourceId,
+		FilePath:   video.FilePath,
+	}
+
+	// Filling in the jobs
+	for index := range video.Jobs {
+		jobDomain := video.Jobs[index]
+		jobOrm := &Job{
+			ID:     jobDomain.Id,
+			Status: string(jobDomain.Status),
+			Error:  jobDomain.Error,
+		}
+		videoORM.Jobs = append(videoORM.Jobs, jobOrm)
+	}
+	return videoORM, nil
+}
+
+func (video *Video) ToVideoDomain() (*domain.Video, error) {
+	videoDomain, err := domain.NewVideo(video.ID, video.ResourceID, video.FilePath)
+	if err != nil {
+		return nil, err
+	}
+	// Filling in the jobs
+	for index := range video.Jobs {
+		jobOrm := video.Jobs[index]
+
+		status, err := domain.OperationStatusFromString(jobOrm.Status)
+		if err != nil {
+			return nil, err
+		}
+
+		jobDomain, err := domain.NewJob(jobOrm.ID, status, videoDomain)
+		if err != nil {
+			return nil, err
+		}
+		videoDomain.Jobs = append(videoDomain.Jobs, jobDomain)
+	}
+	return videoDomain, nil
+}

--- a/application/repositories/video_repository_test.go
+++ b/application/repositories/video_repository_test.go
@@ -1,31 +1,37 @@
 package repositories_test
 
 import (
-	"encoder/application/repositories"
-	"encoder/domain"
-	"encoder/framework/database"
-	"testing"
-	"time"
+ 	"encoder/application/repositories"
+ 	"encoder/framework/database"
+ 	"testing"
 
-	uuid "github.com/satori/go.uuid"
-	"github.com/stretchr/testify/require"
+ 	"github.com/stretchr/testify/require"
 )
 
 func TestVideoRepositoryDbInsert(t *testing.T) {
 	db := database.NewDbTest()
 	defer db.Close()
 
-	video := domain.NewVideo()
-	video.Id = uuid.NewV4().String()
-	video.FilePath = "path"
-	video.CreatedAt = time.Now()
+	video, _ := generateDomainResources()
 
 	repo := repositories.VideoRepositoryDB{Db:db}
-	repo.Insert(video)
+	_, err := repo.Insert(video)
 
-	v, err := repo.Find(video.Id)
-
-	require.NotEmpty(t, v.Id)
 	require.Nil(t, err)
-	require.Equal(t, v.Id, video.Id)
+
+	foundVideo, err := repo.Find(video.Id)
+
+	require.Nil(t, err)
+	require.NotEmpty(t, foundVideo.Id)
+	require.Equal(t, foundVideo.Id, video.Id)
+}
+
+func TestVideoNotFound(t *testing.T) {
+	db := database.NewDbTest()
+	defer db.Close()
+
+	repo := repositories.VideoRepositoryDB{ Db:db }
+	_, err := repo.Find("non-existent-id")
+
+	require.Error(t, err)
 }

--- a/application/repositories/video_test.go
+++ b/application/repositories/video_test.go
@@ -1,0 +1,71 @@
+package repositories_test
+
+import (
+	"encoder/application/repositories"
+	"encoder/domain"
+	"testing"
+
+	uuid "github.com/satori/go.uuid"
+	"github.com/stretchr/testify/require"
+)
+
+func generateDomainResources() (*domain.Video, *domain.Job) {
+	resourceId := "resource-1"
+	filePath := "some/path"
+	videoId := uuid.NewV4().String()
+	domainVideo, _ := domain.NewVideo(videoId, resourceId, filePath)
+
+	jobId := uuid.NewV4().String()
+	jobDomain, _ := domain.NewJob(jobId, domain.STARTING, domainVideo)
+
+	return domainVideo, jobDomain
+}
+
+func TestVideoConversionWithoutJobs(t *testing.T) {
+	video, _ := generateDomainResources()
+
+	videoOrm, err := repositories.ToVideoORM(video)
+
+	require.Nil(t, err)
+	require.Equal(t, video.Id, videoOrm.ID)
+	require.Empty(t, videoOrm.Jobs)
+
+	videoDomain, err := videoOrm.ToVideoDomain()
+
+	require.Nil(t, err)
+	require.Equal(t, videoOrm.ID, videoDomain.Id)
+	require.EqualValues(t, video, videoDomain)
+}
+
+func TestVideoConversionWithJobs(t *testing.T) {
+	// Create original domain resources
+	video, job1 := generateDomainResources()
+	job2, _ := domain.NewJob("", domain.COMPLETED, video)
+
+	video.Jobs = append(video.Jobs, job1)
+	video.Jobs = append(video.Jobs, job2)
+
+	// Translate them into ORM models
+	videoOrm, err := repositories.ToVideoORM(video)
+
+	require.Nil(t, err)
+	require.Len(t, videoOrm.Jobs, 2)
+
+	returnedJobOrm1 := videoOrm.Jobs[0]
+	returnedJobOrm2 := videoOrm.Jobs[1]
+
+	require.Equal(t, job1.Id, returnedJobOrm1.ID)
+	require.Equal(t, job2.Id, returnedJobOrm2.ID)
+
+	// Restore them to domain Entities
+	videoDomain, err := videoOrm.ToVideoDomain()
+
+	require.Nil(t, err)
+	require.Equal(t, video.Id, videoDomain.Id)
+
+	returnedJobDomain1 := videoDomain.Jobs[0]
+	returnedJobDomain2 := videoDomain.Jobs[1]
+
+	require.Equal(t, job1.Id, returnedJobDomain1.Id)
+	require.Equal(t, job2.Id, returnedJobDomain2.Id)
+}

--- a/application/services/job_service.go
+++ b/application/services/job_service.go
@@ -15,7 +15,7 @@ type JobService struct {
 }
 
 func (j *JobService) Start() error {
-	err := j.changeJobStatus("DOWNLOADING")
+	err := j.changeJobStatus(domain.DOWNLOADING)
 	if err != nil {
 		return j.failJob(err)
 	}
@@ -24,7 +24,7 @@ func (j *JobService) Start() error {
 		return j.failJob(err)
 	}
 
-	err = j.changeJobStatus("FRAGMENTING")
+	err = j.changeJobStatus(domain.FRAGMENTING)
 	if err != nil {
 		return j.failJob(err)
 	}
@@ -33,7 +33,7 @@ func (j *JobService) Start() error {
 		return j.failJob(err)
 	}
 
-	err = j.changeJobStatus("ENCODING")
+	err = j.changeJobStatus(domain.ENCODING)
 	if err != nil {
 		return j.failJob(err)
 	}
@@ -42,7 +42,7 @@ func (j *JobService) Start() error {
 		return j.failJob(err)
 	}
 
-	err = j.changeJobStatus("UPLOADING")
+	err = j.changeJobStatus(domain.UPLOADING)
 	if err != nil {
 		return j.failJob(err)
 	}
@@ -51,7 +51,7 @@ func (j *JobService) Start() error {
 		return j.failJob(err)
 	}
 
-	err = j.changeJobStatus("FINISHNING")
+	err = j.changeJobStatus(domain.FINISHNING)
 	if err != nil {
 		return j.failJob(err)
 	}
@@ -60,7 +60,7 @@ func (j *JobService) Start() error {
 		return j.failJob(err)
 	}
 
-	err = j.changeJobStatus("COMPLETED")
+	err = j.changeJobStatus(domain.COMPLETED)
 	if err != nil {
 		return j.failJob(err)
 	}
@@ -76,16 +76,15 @@ func (j *JobService) performUpload() error {
 	doneUpload := make(chan string)
 	go videoUpload.ProcessUpload(concurrency, doneUpload)
 
-	var uploadResult string
-	uploadResult = <-doneUpload
+	var uploadResult string = <-doneUpload
 
-	if uploadResult != domain.COMPLETED.String() {
+	if uploadResult != domain.COMPLETED.ToString() {
 		return j.failJob(errors.New(uploadResult))
 	}
 	return nil
 }
 
-func (j *JobService) changeJobStatus(status string) error {
+func (j *JobService) changeJobStatus(status domain.OperationStatus) error {
 	var err error
 
 	j.Job.Status = status

--- a/application/services/job_worker.go
+++ b/application/services/job_worker.go
@@ -5,27 +5,25 @@ import (
 	"encoder/framework/utils"
 	"encoding/json"
 	"log"
-	"os"
 	"sync"
-	"time"
 
 	uuid "github.com/satori/go.uuid"
 	"github.com/streadway/amqp"
 )
 
 type JobWorkerResult struct {
-	Job domain.Job
+	Job     domain.Job
 	Message amqp.Delivery
-	Error error
+	Error   error
 }
 
 var Mutex = &sync.Mutex{}
 
 func returnJobResult(job domain.Job, message amqp.Delivery, err error) JobWorkerResult {
 	result := JobWorkerResult{
-		Job: job,
+		Job:     job,
 		Message: message,
-		Error: err,
+		Error:   err,
 	}
 	return result
 }
@@ -72,15 +70,14 @@ func JobWorker(messageChannel chan amqp.Delivery, returnChan chan JobWorkerResul
 		log.Println("Video successfully stored in the database.")
 
 		job.Video = jobService.VideoService.Video
-		job.OutputBucketPath = os.Getenv("OUTPUT_BUCKET_NAME")
+		//job.OutputBucketPath = os.Getenv("OUTPUT_BUCKET_NAME")
 		job.Id = uuid.NewV4().String()
-		job.Status = domain.STARTING.String()
-		job.CreatedAt = time.Now()
+		job.Status = domain.STARTING
 
 		Mutex.Lock()
 		_, err = jobService.JobRepository.Insert(&job)
 		Mutex.Unlock()
-		
+
 		if err != nil {
 			returnChan <- returnJobResult(domain.Job{}, message, err)
 			continue
@@ -95,5 +92,5 @@ func JobWorker(messageChannel chan amqp.Delivery, returnChan chan JobWorkerResul
 			continue
 		}
 		returnChan <- returnJobResult(job, message, nil)
-	}	
+	}
 }

--- a/application/services/upload_manager.go
+++ b/application/services/upload_manager.go
@@ -11,7 +11,7 @@ import (
 type VideoUpload struct {
 	Paths        []string
 	VideoPath    string
-	OutputBucket string // it should be an abstraction (repository), not a bucket name
+	OutputBucket string      // it should be an abstraction (repository), not a bucket name
 	Errors       []string
 }
 
@@ -77,7 +77,7 @@ func (vu *VideoUpload) ProcessUpload(concurrency int, doneUpload chan string) er
 	}()
 
 	for r := range returnChannel {
-		if r != "" {
+		if r != domain.SUCCEEDED.ToString() {
 			doneUpload <- r
 			break
 		}
@@ -97,7 +97,7 @@ func (vu *VideoUpload) UploadWorker(in chan int, returnChan chan string) {
 			log.Printf("error during the upload: %v. Error: %v", vu.Paths[x], err)
 			returnChan <- err.Error()
 		}
-		returnChan <- ""
+		returnChan <- domain.SUCCEEDED.ToString()
 	}
-	returnChan <- domain.COMPLETED.String()
+	returnChan <- domain.COMPLETED.ToString()
 }

--- a/application/services/upload_manager_test.go
+++ b/application/services/upload_manager_test.go
@@ -28,7 +28,7 @@ func TestVideoServiceUpload(t *testing.T) {
 	doneUpload := make(chan string)
 	go videoUpload.ProcessUpload(20, doneUpload)
 
-	result := <-doneUpload
+	result := <- doneUpload
 	require.Empty(t, videoUpload.Errors)
-	require.Equal(t, result, domain.COMPLETED.String())
+	require.Equal(t, result, domain.COMPLETED.ToString())
 }

--- a/application/services/video_service_test.go
+++ b/application/services/video_service_test.go
@@ -8,10 +8,8 @@ import (
 	"log"
 	"os"
 	"testing"
-	"time"
 
 	"github.com/joho/godotenv"
-	uuid "github.com/satori/go.uuid"
 	"github.com/stretchr/testify/require"
 )
 
@@ -26,12 +24,7 @@ func prepare() (*domain.Video, repositories.VideoRepositoryDB) {
 	db := database.NewDbTest()
 	defer db.Close()
 
-	video := domain.NewVideo()
-	video.Id = uuid.NewV4().String()
-	//video.FilePath = "tbs_tests/input/data/test/test.mp4"
-	video.FilePath = "test.mp4"
-	video.CreatedAt = time.Now()
-
+	video, _ := domain.NewVideo("", "resource-id", "test.mp4")
 	repo := repositories.VideoRepositoryDB{Db:db}
 	return video, repo
 }

--- a/docs/refactoring.md
+++ b/docs/refactoring.md
@@ -6,7 +6,6 @@ This documentation was created to list those issues for further revision and adj
 ## Backlog
 
 ### Repositories
-- [ ] Remove database configuration from entity definition on `Video` and `Job`
 - [ ] Fix ORM error when handling with column referencing objects. Ex.: Object `Job` has a attribute `Video` that is returned by the ORM (Maybe it is a `sqlite3.orm` limitation)
 
 ### Services
@@ -45,3 +44,4 @@ This documentation was created to list those issues for further revision and adj
 - [x] Create a `resources` folder to be used by the unit tests
 - [x] In the Finish function, replace the `os.Getenv` calls by a variable
 - [x] Find a standard way to comment on the `queue.go` giving the credits to the author (wesley willians)
+- [x] Remove database configuration from entity definition on `Video` and `Job`

--- a/domain/job.go
+++ b/domain/job.go
@@ -1,10 +1,8 @@
 package domain
 
 import (
-	"time"
-
-	uuid "github.com/satori/go.uuid"
 	"github.com/asaskevich/govalidator"
+	uuid "github.com/satori/go.uuid"
 )
 
 func init() {
@@ -12,36 +10,27 @@ func init() {
 }
 
 type Job struct {
-	Id string `json:"job_id" valid:"uuid" gorm:"type:uuid;primary_key"`
-	OutputBucketPath string `json:"output_bucket_path" valid:"notnull"`
-	Status string `json:"status" valid:"notnull"`
-	Video *Video `json:"video" valid:"-"`
-	VideoId string `json:"-" valid:"-" gorm:"column:video_id;type:uuid REFERENCES videos(id);notnull"`
-	Error string `valid:"-"`
-	CreatedAt time.Time `json:"created_at" valid:"-"`
-	UpdatedAt time.Time `json:"updated_at" valid:"-"`
+	Id               string          `json:"job_id" valid:"uuid"`
+	Status           OperationStatus `json:"status" valid:"notnull"`
+	Video            *Video          `json:"video" valid:"required"`
+	Error            string          `valid:"-"`
 }
 
-func NewJob(output string, status string, video *Video) (*Job, error) {
-	job := Job{
-		OutputBucketPath: output,
-		Status: status,
-		Video: video,
+func NewJob(id string, status OperationStatus, video *Video) (*Job, error) {
+	if id == "" {
+		id = uuid.NewV4().String()
 	}
-	job.prepare()
-
+	job := Job{
+		Id:               id,
+		Status:           status,
+		Video:            video,
+	}
 	err := job.Validate()
 
 	if err != nil {
 		return nil, err
 	}
 	return &job, nil
-}
-
-func (job *Job) prepare() {
-	job.Id = uuid.NewV4().String()
-	job.CreatedAt = time.Now()
-	job.UpdatedAt = time.Now()
 }
 
 func (job *Job) Validate() error {

--- a/domain/job_test.go
+++ b/domain/job_test.go
@@ -3,20 +3,35 @@ package domain_test
 import (
 	"encoder/domain"
 	"testing"
-	"time"
 
 	uuid "github.com/satori/go.uuid"
 	"github.com/stretchr/testify/require"
 )
 
-func TestNew(t *testing.T) {
-	video := domain.NewVideo()
-	video.Id = uuid.NewV4().String()
-	video.FilePath = "some/file"
-	video.CreatedAt = time.Now()
-
-	job, err := domain.NewJob("some/path", "Converted", video)
-
-	require.NotNil(t, job)
+func TestJobIdIsEmpty(t *testing.T) {
+	video, err := domain.NewVideo("", "123", "some/path")
 	require.Nil(t, err)
+
+	job, err := domain.NewJob("", domain.STARTING, video)
+	require.Nil(t, err)
+	require.NotEmpty(t, job.Id)
+	require.Equal(t, domain.STARTING, job.Status)
+}
+
+func TestVideoIdIsNotUUID(t *testing.T) {
+	video, err := domain.NewVideo("", "123", "some/path")
+	require.Nil(t, err)
+
+	_, err = domain.NewJob("123", domain.STARTING, video)
+	require.Error(t, err)
+}
+
+func TestExistingVideoId(t *testing.T) {
+	video, err := domain.NewVideo("", "123", "some/path")
+	require.Nil(t, err)
+
+	id := uuid.NewV4().String()
+	job, err := domain.NewJob(id, domain.STARTING, video)
+	require.Nil(t, err)
+	require.Equal(t, id, job.Id)
 }

--- a/domain/states.go
+++ b/domain/states.go
@@ -1,24 +1,44 @@
 package domain
 
-type OperationStatus int8
-
-const (
-	SUCCEEDED OperationStatus = iota
-	FAILED
-	COMPLETED
-	STARTING
+import (
+	"fmt"
 )
 
-func (status OperationStatus) String() string {
-	switch status {
-	case SUCCEEDED:
-		return "succeeded"
-	case FAILED:
-		return "failed"
-	case COMPLETED:
-		return "completed"
-	case STARTING:
-		return "starting"
-	}
-	return "unknown"
+type OperationStatus string
+
+const (
+	SUCCEEDED OperationStatus = "SUCCEEDED"
+	FAILED    OperationStatus = "FAILED"
+	COMPLETED OperationStatus = "COMPLETED"
+	STARTING  OperationStatus = "STARTING"
+	DOWNLOADING OperationStatus = "DOWNLOADING"
+	FRAGMENTING OperationStatus = "FRAGMENTING"
+	ENCODING OperationStatus = "ENCODING"
+	UPLOADING OperationStatus = "UPLOADING"
+	FINISHNING OperationStatus = "FINISHING"
+)
+
+var stringToOperationStatus = map[string]OperationStatus{
+	"SUCCEEDED": SUCCEEDED,
+	"FAILED": FAILED,
+	"COMPLETED": COMPLETED,
+	"STARTING": STARTING,
+	"DOWNLOADING": DOWNLOADING,
+	"FRAGMENTING": FRAGMENTING,
+	"ENCODING": ENCODING,
+	"UPLOADING": UPLOADING,
+	"FINISHNING": FINISHNING,
 }
+
+func (os OperationStatus) ToString() string {
+	return string(os)
+}
+
+func OperationStatusFromString(s string) (OperationStatus, error) {
+	status, ok := stringToOperationStatus[s]
+	if !ok {
+		return "", fmt.Errorf("unknown OperationStatus: %s", s)
+	}	
+	return status, nil
+}
+

--- a/domain/video.go
+++ b/domain/video.go
@@ -1,30 +1,41 @@
 package domain
 
 import (
-	"time"
-
 	"github.com/asaskevich/govalidator"
+	uuid "github.com/satori/go.uuid"
 )
 
 type Video struct {
-	Id string `json:"encoded_video_folder" valid:"uuid" gorm:"type:uuid;primary_key"`
-	ResourceId string `json:"resource_id" valid:"notnull" gorm:"type:varchar(255)"`
-	FilePath string `json:"file_path" valid:"notnull" gorm:"type:varchar(255)"`
-	CreatedAt time.Time `json:"-" valid:"-"`
-	Jobs []*Job `json:"-" valid:"-" gorm:"ForeignKey:VideoId"`
+	Id         string `json:"encoded_video_folder" valid:"uuid"`
+	ResourceId string `json:"resource_id" valid:"notnull"`
+	FilePath   string `json:"file_path" valid:"notnull"`
+	Jobs       []*Job `json:"-" valid:"-"`
 }
 
 func init() {
 	govalidator.SetFieldsRequiredByDefault(true)
 }
 
-func NewVideo() *Video {
-	return &Video{}
+func NewVideo(id string, resourceId string, filePath string) (*Video, error) {
+	if id == "" {
+		id = uuid.NewV4().String()
+	}
+	video := Video{
+		Id:         id,
+		ResourceId: resourceId,
+		FilePath:   filePath,
+		Jobs:       []*Job{},
+	}
+	err := video.Validate()
+
+	if err != nil {
+		return nil, err
+	}
+	return &video, nil
 }
 
 func (video *Video) Validate() error {
 	_, err := govalidator.ValidateStruct(video)
-
 	if err != nil {
 		return err
 	}

--- a/domain/video_test.go
+++ b/domain/video_test.go
@@ -3,39 +3,35 @@ package domain_test
 import (
 	"encoder/domain"
 	"testing"
-	"time"
 
 	uuid "github.com/satori/go.uuid"
 	"github.com/stretchr/testify/require"
 )
 
-func TestValidateIfVideoIsEmpty(t *testing.T) {
-	video := domain.NewVideo()
-	err := video.Validate()
+func TestIdIsEmpty(t *testing.T) {
+	resourceId := "resource-1"
+	filePath := "some/path"
+	video, err := domain.NewVideo("", resourceId, filePath)
 
-	require.Error(t, err)
-}
-
-func TestVideoIdIsNotUUID(t *testing.T) {
-	video := domain.NewVideo()
-	video.Id = "abc"
-	video.ResourceId = "a"
-	video.FilePath = "/some/file"
-	video.CreatedAt = time.Now()
-
-	err := video.Validate()
-	require.Error(t, err)
-
-}
-
-func TestVideoIsValid(t *testing.T) {
-	video := domain.NewVideo()
-	video.Id = uuid.NewV4().String()
-	video.ResourceId = "a"
-	video.FilePath = "/some/file"
-	video.CreatedAt = time.Now()
-
-	err := video.Validate()
 	require.Nil(t, err)
+	require.Equal(t, resourceId, video.ResourceId)
+	require.Equal(t, filePath, video.FilePath)
+}
 
+func TestIdIsNotUUID(t *testing.T) {
+	resourceId := "resource-1"
+	filePath := "some/path"
+	_, err := domain.NewVideo("123", resourceId, filePath)
+
+	require.Error(t, err)
+}
+
+func TestExistingId(t *testing.T) {
+	resourceId := "resource-1"
+	filePath := "some/path"
+	id := uuid.NewV4().String()
+	video, err := domain.NewVideo(id, resourceId, filePath)
+
+	require.Nil(t, err)
+	require.Equal(t, id, video.Id)
 }

--- a/framework/database/db.go
+++ b/framework/database/db.go
@@ -1,8 +1,9 @@
 package database
 
 import (
-	"encoder/domain"
+	"encoder/application/repositories"
 	"log"
+
 	"github.com/jinzhu/gorm"
 	_ "github.com/jinzhu/gorm/dialects/sqlite"
 	_ "github.com/lib/pq"
@@ -29,7 +30,7 @@ func NewDbTest() *gorm.DB {
 	dbInstance.DbTypeTest = "sqlite3"
 	dbInstance.DsnTest = ":memory:"
 	dbInstance.AutoMigrateDb = true
-	dbInstance.Debug = true
+	dbInstance.Debug = false
 
 	connection, err := dbInstance.Connect()
 
@@ -57,9 +58,9 @@ func (d *Database) Connect() (*gorm.DB, error) {
 	}
 
 	if d.AutoMigrateDb {
-		d.Db.AutoMigrate(&domain.Video{}, &domain.Job{},)
+		d.Db.AutoMigrate(&repositories.Video{}, &repositories.Job{},)
 		//d.Db.Raw("PRAGMA foreign_keys=ON")
-		d.Db.Model(domain.Job{}).AddForeignKey("video_id", "videos (id)", "CASCADE", "CASCADE")
+		d.Db.Model(repositories.Job{}).AddForeignKey("video_id", "videos (id)", "CASCADE", "CASCADE")
 	}
 	return d.Db, nil
 }


### PR DESCRIPTION
This MR uncouple the database definitions from the `domain` entities `Video` and `Job`.  After that, it was necessary to update the repository to use the ORM models.